### PR TITLE
Updated used cron library to version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Nothing so far
+- Updated the used cron library to version 3
 
 ## [v1.0.0] - 2020-02-28
 - Use error wrapping of standard library instead of github.com/pkg/errors

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ func main() {
 		// emit your own custom event every day at 09:00
 		cron.ScheduleEvent("0 9 * * *", MyEvent{}), 
 		
+		// emit your own custom event every day at 09:00:30
+		cron.ScheduleEvent("30 0 9 * * *", MyEvent{}),
+
 		// cron expressions can be hard to read and might be overkill
 		cron.ScheduleEventEvery(time.Hour, MyEvent{}), 
 		

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/go-joe/joe v0.6.0
 	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967
+	github.com/robfig/cron/v3 v3.0.0
 	github.com/stretchr/testify v1.3.0
 	go.uber.org/zap v1.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967 h1:x7xEyJDP7Hv3LVgvWhzioQqbC/KtuUhTigKlH/8ehhE=
 github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=

--- a/module_test.go
+++ b/module_test.go
@@ -214,7 +214,7 @@ func TestJob_InvalidSchedule(t *testing.T) {
 	job := cron.ScheduleEvent("foobar")
 
 	err := job.Start(logger, brain)
-	require.EqualError(t, err, "invalid cron schedule: Expected 5 to 6 fields, found 1: foobar")
+	require.EqualError(t, err, "invalid cron schedule: expected 5 to 6 fields, found 1: [foobar]")
 }
 
 func TestExampleSchedule(t *testing.T) {
@@ -284,7 +284,7 @@ func TestScheduleEvent_Error(t *testing.T) {
 	job := cron.ScheduleEvent("foobar")
 
 	err := job.Start(logger, brain)
-	require.EqualError(t, err, "invalid cron schedule: Expected 5 to 6 fields, found 1: foobar")
+	require.EqualError(t, err, "invalid cron schedule: expected 5 to 6 fields, found 1: [foobar]")
 
 	assert.NoError(t, job.Close())
 	brain.Finish()
@@ -299,7 +299,7 @@ func TestScheduleFunc_Error(t *testing.T) {
 	})
 
 	err := job.Start(logger, brain)
-	require.EqualError(t, err, "invalid cron schedule: Expected 5 to 6 fields, found 1: foobar")
+	require.EqualError(t, err, "invalid cron schedule: expected 5 to 6 fields, found 1: [foobar]")
 
 	assert.NoError(t, job.Close())
 	brain.Finish()


### PR DESCRIPTION
Hey, 

I noticed that the used cron library [robfig/cron](https://github.com/robfig/cron) is at version 3 by now whereas the current version of the module uses a much older version. Version 3 of this library aligns more with the standard notion of defining cron schedules, i.e. omits seconds.

For downwards-compatibility, I added a default schedule parser that accepts standard cron schedules with optional seconds. A future PR could contain changes to the functions in a form that they accept options so that the caller can explicity state the format of their cron schedule.